### PR TITLE
Fix payment insert query

### DIFF
--- a/api/queries/private.js
+++ b/api/queries/private.js
@@ -26,8 +26,8 @@ const newsletterQueryTemplate = (columns, news_type) => (
 )
 
 exports.update_subscription = body =>
-  `insert into payments (member, category, amount)
-  select id, 'subscription', amount from members, membershiptypes
+  `insert into payments (member, category, amount, createdAt)
+  select id, 'subscription', amount, now() from members, membershiptypes
   where members.membership_type = membershiptypes.value
   and news_type = '${body.news_type}'
   and members.membership_type in

--- a/api/queries/private.js
+++ b/api/queries/private.js
@@ -26,8 +26,8 @@ const newsletterQueryTemplate = (columns, news_type) => (
 )
 
 exports.update_subscription = body =>
-  `insert into payments (member, category, amount, createdAt)
-  select id, 'subscription', amount, now() from members, membershiptypes
+  `insert into payments (member, category, amount, date, createdAt)
+  select id, 'subscription', amount, curdate(), now() from members, membershiptypes
   where members.membership_type = membershiptypes.value
   and news_type = '${body.news_type}'
   and members.membership_type in


### PR DESCRIPTION
@rjmk just looking at the waterline model document you sent over. I tried the defaultsTo option originally and it seemed to work for the payments added when the app first starts up. However it did not work when I added the subscription due payments when sending off those letters/emails. I am going to see if the document mentions anything I have not done. I was wondering whether this is preferable to updating the query as in this PR. 
