### PR TITLE
Fix insert sub due query.

### DIFF
--- a/api/queries/private.js
+++ b/api/queries/private.js
@@ -39,6 +39,7 @@ exports.update_subscription = body =>
   select id, 'subscription', 'Subscription', amount, ${set_current('due_date')}, now()
   from members, membershiptypes
   where members.membership_type = membershiptypes.value
+  and (standing_order is null or standing_order=false)
   and members.membership_type in
   ('annual-single', 'annual-double', 'annual-family', 'annual-corporate', 'annual-group')
   and members.primary_email is${body.news_type === 'online' ? ' not' : ''} null


### PR DESCRIPTION
@rjmk I got a little sidetracked. Richard got back to me to tell me that September subscriptions were now working with 11 month change. I was a little suspicious about the amount of results that he got back so I went to investigate. Turns out these were all fine. However I noticed that too many payments were being inserted. Traced the error back to this. 

Unfortunately this means that every time he has generated subscription payments, he must have been generating them for members with `standing_order` set to `true`. Should we let we him know about it or is there a way we can clear this up?
