### PR TITLE
New member payment bug

### DIFF
--- a/api/controllers/PrivateController.js
+++ b/api/controllers/PrivateController.js
@@ -43,6 +43,7 @@ module.exports = {
     member.life_payment_date = (Is.ok(member.life_payment_date) ? member.life_payment_date : null)
     member.due_date = (Is.ok(member.due_date) ? member.due_date : null)
     member.date_gift_aid_signed = (Is.ok(member.date_gift_aid_signed) ? member.date_gift_aid_signed : null)
+    member.date_membership_type_changed = (Is.ok(member.date_membership_type_changed) ? member.date_membership_type_changed : null)
     member.date_gift_aid_cancelled = (Is.ok(member.date_gift_aid_cancelled) ? member.date_gift_aid_cancelled : null)
     member.primary_email = (Is.ok(member.primary_email) ? member.primary_email : null)
 

--- a/src/admin/dumb_components/member_payments.js
+++ b/src/admin/dumb_components/member_payments.js
@@ -1,5 +1,5 @@
 const React = require('react')
-const { map, dissoc } = require('ramda')
+const { map, assoc } = require('ramda')
 const { types, type_order } = require('../form_fields/charge_form.js')
 
 const PaymentsTable = require('../../shared/components/payments_table')
@@ -47,6 +47,6 @@ var MemberPayments = (
     </div>
   </div>
 
-const with_amount = (type, defaults) => type === 'subscription' ? defaults : dissoc('amount', defaults)
+const with_amount = (type, defaults) => type === 'subscription' ? defaults : assoc('amount', '', defaults)
 
 module.exports = MemberPayments

--- a/src/admin/form_fields/charge_form.js
+++ b/src/admin/form_fields/charge_form.js
@@ -1,5 +1,4 @@
-const { concat, contains, prop, equals, not, propOr, compose, test, curry
-  , keys, assoc, converge, merge, complement, defaultTo } =
+const { concat, prop, compose, test, converge, merge, defaultTo } =
     require('ramda')
 const { exists, selected, check_tests, date } = require('app/validate')
 

--- a/src/admin/redux/modules/payment_defaults.js
+++ b/src/admin/redux/modules/payment_defaults.js
@@ -1,9 +1,5 @@
 /* @flow */
 const { FETCHED_MEMBER } = require('../../../shared/redux/modules/member.js')
-const { ADDED_PAYMENT } = require('../../../shared/redux/modules/payments.js')
-const { format } = require('app/transform_dated.js')
-const { reduce, keys, compose } = require('ramda')
-
 import type { Action, Reducer } from 'redux'
 
 type Category = 'payment' | 'subscription' | 'donation' | 'event' | ''
@@ -37,18 +33,6 @@ const payment_defaults : Reducer<Payment, Action>
     switch (type) {
       case FETCHED_MEMBER:
         return {...state, amount: String(payload.subscription_amount / 100) }
-      case ADDED_PAYMENT:
-        return compose
-          ( format
-          , reduce
-            ( (state, field) =>
-                field.match(/^date|reference|type$/)
-                ? { ...state, [field]: payload[field] }
-                : state
-            , state
-            )
-          , keys
-          )(payload)
       default:
         return state
     }

--- a/src/admin/redux/modules/payment_defaults.js
+++ b/src/admin/redux/modules/payment_defaults.js
@@ -1,5 +1,9 @@
 /* @flow */
 const { FETCHED_MEMBER } = require('../../../shared/redux/modules/member.js')
+const { ADDED_PAYMENT } = require('../../../shared/redux/modules/payments.js')
+const { format } = require('app/transform_dated.js')
+const { reduce, keys, compose } = require('ramda')
+
 import type { Action, Reducer } from 'redux'
 
 type Category = 'payment' | 'subscription' | 'donation' | 'event' | ''
@@ -33,6 +37,18 @@ const payment_defaults : Reducer<Payment, Action>
     switch (type) {
       case FETCHED_MEMBER:
         return {...state, amount: String(payload.subscription_amount / 100) }
+      case ADDED_PAYMENT:
+        return compose
+          ( format
+          , reduce
+            ( (state, field) =>
+                field.match(/^date|reference|type$/)
+                ? { ...state, [field]: payload[field] }
+                : state
+            , state
+            )
+          , keys
+          )(payload)
       default:
         return state
     }


### PR DESCRIPTION
@rjmk I think this fixes the payment bug from Richard's email. I am a little confused as to why the `default_payments` bit of state was being changed when a payment was added. This meant that if you went to input a new payment, all the fields would be filled in with the previously entered payment. Is taking this case out of `default_payments` reducer good, or have I missed something? Also fixed a little bug in the form to add a member.
