### PR TITLE
Removing grunt integration by disabling grunt hook in a .sailsrc file

### DIFF
--- a/.sailsrc
+++ b/.sailsrc
@@ -1,0 +1,5 @@
+{
+    "hooks": {
+        "grunt": false
+    }
+}


### PR DESCRIPTION
Grunt was not used and results in a warning / error on build