### PR TITLE
add maintanence page if env variable is set

### DIFF
--- a/api/controllers/PublicController.js
+++ b/api/controllers/PublicController.js
@@ -10,8 +10,9 @@ var Mailgun = require('../services/email_mailgun')
 module.exports = {
 
   showHome: function (req, res) {
-    res.view('pages/maintenance', {user: req.session.user})
-    // res.view('pages/open', {user: req.session.user})
+    process.env.MAINTENANCE
+      ? res.view('pages/maintenance', {user: req.session.user})
+      : res.view('pages/open', {user: req.session.user})
   },
 
   ServiceSignIn: function (req, res) {


### PR DESCRIPTION
Helpful in development to not see maintenance page. Env variable already set on heroku so this can be merged.