### PR TITLE
add auto answer to backup script

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build": "browserify src/admin/main.js > .tmp/public/js/admin.min.js & browserify src/user/main.js > .tmp/public/js/user.min.js & browserify src/open/main.js > .tmp/public/js/open.min.js & node-sass src/styles/main.scss .tmp/public/styles/main.css",
     "build:w": "watchify src/admin/main.js -o .tmp/public/js/admin.min.js & watchify src/user/main.js -o .tmp/public/js/user.min.js & watchify src/open/main.js -o .tmp/public/js/open.min.js & node-sass -w src/styles/main.scss .tmp/public/styles/main.css",
     "postinstall": "npm run backup",
-    "backup": "bash ./scripts/db/run-backup.sh"
+    "backup": "echo \"A\" | bash ./scripts/db/run-backup.sh"
   },
   "standard": {
     "ignore": [


### PR DESCRIPTION
We need to ensure that we download the aws cli bundle on Heroku every time due to non persistent file storage. Do this by always responding to the prompt with `"A"` (all)