### PR TITLE
Fix S3 auto backup issue on Heroku

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build": "browserify src/admin/main.js > .tmp/public/js/admin.min.js & browserify src/user/main.js > .tmp/public/js/user.min.js & browserify src/open/main.js > .tmp/public/js/open.min.js & node-sass src/styles/main.scss .tmp/public/styles/main.css",
     "build:w": "watchify src/admin/main.js -o .tmp/public/js/admin.min.js & watchify src/user/main.js -o .tmp/public/js/user.min.js & watchify src/open/main.js -o .tmp/public/js/open.min.js & node-sass -w src/styles/main.scss .tmp/public/styles/main.css",
     "postinstall": "npm run backup",
-    "backup": "echo \"A\" | bash ./scripts/db/run-backup.sh"
+    "backup": "bash ./scripts/db/run-backup.sh"
   },
   "standard": {
     "ignore": [

--- a/scripts/db/run-backup.sh
+++ b/scripts/db/run-backup.sh
@@ -4,13 +4,15 @@ if [ ! $NODE_ENV = 'heroku' ] && [ ! $NODE_ENV = 'production' ]; then
   exit
 fi
 
-#install aws-cli if it doesn't exist
-if [ ! -d "/tmp/aws" ]; then
-  curl https://s3.amazonaws.com/aws-cli/awscli-bundle.zip -o awscli-bundle.zip
-  unzip awscli-bundle.zip
-  chmod +x ./awscli-bundle/install
-  ./awscli-bundle/install -i /tmp/aws
-fi
+# install leftover and create /tmp/aws_install directory for new installation
+rm -rf /tmp/aws && rm -rf /tmp/aws_install
+mkdir /tmp/aws_install
+
+# download and unzip aws cli tools to /tmp/aws
+curl https://s3.amazonaws.com/aws-cli/awscli-bundle.zip -o /tmp/aws_install/awscli-bundle.zip
+unzip /tmp/aws_install/awscli-bundle.zip -d /tmp/aws_install/
+chmod +x /tmp/aws_install/awscli-bundle/install
+/tmp/aws_install/awscli-bundle/install -i /tmp/aws
 
 # new backup file name
 BACKUP_FILE_NAME="$(date +"%Y-%m-%d-%H-%M")-$APP-$DB_DATABASE.sql"


### PR DESCRIPTION
Heroku's ephemeral file system is causing major issues with the aws cli install. We can get around this by removing the previous aws cli install artefacts and re-installing the cli each time the script is run.